### PR TITLE
Fix: Update the import path for the Kaiser window.

### DIFF
--- a/chcochleagram/downsampling.py
+++ b/chcochleagram/downsampling.py
@@ -75,7 +75,7 @@ class SincWithKaiserWindow(DownsampleEnvelopes):
         downsample_filter_response_orig = (np.sinc(downsample_filter_times / 
                                                   self.downsample_factor) /
                                               self.downsample_factor)
-        downsample_filter_window = signal.kaiser(self.window_size, 5)
+        downsample_filter_window = signal.windows.kaiser(self.window_size, 5)
         downsample_filter_response = (downsample_filter_window * 
                                          downsample_filter_response_orig)
         downsample_filter_response = np.expand_dims(np.expand_dims(


### PR DESCRIPTION
In the updated version of SciPy, `scipy.signal.kaiser` has been relocated to `scipy.signal.windows.kaiser`.